### PR TITLE
UFOs rank indices

### DIFF
--- a/ufos/src/lib.rs
+++ b/ufos/src/lib.rs
@@ -249,6 +249,30 @@ impl From<TopCollections> for Vec<String> {
     }
 }
 
+#[derive(Debug)]
+pub struct QueryPeriod {
+    from: Option<Cursor>,
+    until: Option<Cursor>,
+}
+impl QueryPeriod {
+    pub fn all_time() -> Self {
+        QueryPeriod {
+            from: None,
+            until: None,
+        }
+    }
+    pub fn is_all_time(&self) -> bool {
+        self.from.is_none() && self.until.is_none()
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct Count {
+    thing: String,
+    records: u64,
+    dids_estimate: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ufos/src/server.rs
+++ b/ufos/src/server.rs
@@ -1,6 +1,6 @@
 use crate::index_html::INDEX_HTML;
 use crate::storage::StoreReader;
-use crate::{ConsumerInfo, Nsid, TopCollections, UFOsRecord};
+use crate::{ConsumerInfo, Count, Nsid, QueryPeriod, TopCollections, UFOsRecord};
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::Body;
@@ -213,6 +213,21 @@ async fn get_records_total_seen(
     ok_cors(seen_by_collection)
 }
 
+/// Get top collections by count
+#[endpoint {
+    method = GET,
+    path = "/collections/by-count"
+}]
+async fn get_top_collections_by_count(ctx: RequestContext<Context>) -> OkCorsResponse<Vec<Count>> {
+    let Context { storage, .. } = ctx.context();
+    let collections = storage
+        .get_top_collections_by_count(100, QueryPeriod::all_time())
+        .await
+        .map_err(|e| HttpError::for_internal_error(format!("oh shoot: {e:?}")))?;
+
+    ok_cors(collections)
+}
+
 /// Get top collections
 ///
 /// The format of this API response will be changing soon.
@@ -244,6 +259,7 @@ pub async fn serve(storage: impl StoreReader + 'static) -> Result<(), String> {
     api.register(get_meta_info).unwrap();
     api.register(get_records_by_collections).unwrap();
     api.register(get_records_total_seen).unwrap();
+    api.register(get_top_collections_by_count).unwrap();
     api.register(get_top_collections).unwrap();
 
     let context = Context {

--- a/ufos/src/storage.rs
+++ b/ufos/src/storage.rs
@@ -76,6 +76,12 @@ pub trait StoreReader: Send + Sync {
         period: QueryPeriod,
     ) -> StorageResult<Vec<Count>>;
 
+    async fn get_top_collections_by_dids(
+        &self,
+        limit: usize,
+        period: QueryPeriod,
+    ) -> StorageResult<Vec<Count>>;
+
     async fn get_top_collections(&self) -> StorageResult<TopCollections>;
 
     async fn get_counts_by_collection(&self, collection: &Nsid) -> StorageResult<(u64, u64)>;

--- a/ufos/src/storage.rs
+++ b/ufos/src/storage.rs
@@ -1,4 +1,7 @@
-use crate::{error::StorageError, ConsumerInfo, Cursor, EventBatch, TopCollections, UFOsRecord};
+use crate::{
+    error::StorageError, ConsumerInfo, Count, Cursor, EventBatch, QueryPeriod, TopCollections,
+    UFOsRecord,
+};
 use async_trait::async_trait;
 use jetstream::exports::{Did, Nsid};
 use std::collections::HashSet;
@@ -66,6 +69,12 @@ pub trait StoreReader: Send + Sync {
     async fn get_storage_stats(&self) -> StorageResult<serde_json::Value>;
 
     async fn get_consumer_info(&self) -> StorageResult<ConsumerInfo>;
+
+    async fn get_top_collections_by_count(
+        &self,
+        limit: usize,
+        period: QueryPeriod,
+    ) -> StorageResult<Vec<Count>>;
 
     async fn get_top_collections(&self) -> StorageResult<TopCollections>;
 

--- a/ufos/src/storage_fjall.rs
+++ b/ufos/src/storage_fjall.rs
@@ -359,7 +359,37 @@ impl FjallReader {
                     "integrity: all-time rank rollup must have corresponding all-time count rollup",
                 );
                 let db_counts = db_complete::<CountsValue>(&db_count_bytes)?;
-                assert_eq!(db_counts.records(), key.records());
+                assert_eq!(db_counts.records(), key.count());
+                out.push(Count {
+                    thing: key.collection().to_string(),
+                    records: db_counts.records(),
+                    dids_estimate: db_counts.dids().estimate() as u64,
+                });
+            }
+            out
+        } else {
+            todo!()
+        })
+    }
+
+    fn get_top_collections_by_dids(
+        &self,
+        limit: usize,
+        period: QueryPeriod,
+    ) -> StorageResult<Vec<Count>> {
+        Ok(if period.is_all_time() {
+            let snapshot = self.rollups.snapshot();
+            let mut out = Vec::with_capacity(limit);
+            let prefix = AllTimeDidsKey::from_prefix_to_db_bytes(&Default::default())?;
+            for kv in snapshot.prefix(prefix).rev().take(limit) {
+                let (key_bytes, _) = kv?;
+                let key = db_complete::<AllTimeDidsKey>(&key_bytes)?;
+                let rollup_key = AllTimeRollupKey::new(key.collection());
+                let db_count_bytes = snapshot.get(rollup_key.to_db_bytes()?)?.expect(
+                    "integrity: all-time rank rollup must have corresponding all-time count rollup",
+                );
+                let db_counts = db_complete::<CountsValue>(&db_count_bytes)?;
+                assert_eq!(db_counts.dids().estimate() as u64, key.count());
                 out.push(Count {
                     thing: key.collection().to_string(),
                     records: db_counts.records(),
@@ -521,6 +551,17 @@ impl StoreReader for FjallReader {
         let s = self.clone();
         tokio::task::spawn_blocking(move || {
             FjallReader::get_top_collections_by_count(&s, limit, period)
+        })
+        .await?
+    }
+    async fn get_top_collections_by_dids(
+        &self,
+        limit: usize,
+        period: QueryPeriod,
+    ) -> StorageResult<Vec<Count>> {
+        let s = self.clone();
+        tokio::task::spawn_blocking(move || {
+            FjallReader::get_top_collections_by_dids(&s, limit, period)
         })
         .await?
     }

--- a/ufos/src/storage_fjall.rs
+++ b/ufos/src/storage_fjall.rs
@@ -70,19 +70,44 @@ const MAX_BATCHED_ROLLUP_COUNTS: usize = 256;
 ///      - key: "live_counts" || u64 || nullstr (js_cursor, nsid)
 ///      - val: u64 || HLL (count (not cursor), estimator)
 ///
+///
 /// - Hourly total record counts and dids estimate per collection
 ///      - key: "hourly_counts" || u64 || nullstr (hour, nsid)
 ///      - val: u64 || HLL (count (not cursor), estimator)
 ///
+/// - Hourly record count ranking
+///      - key: "hourly_rank_records" || u64 || u64 || nullstr (hour, count, nsid)
+///      - val: [empty]
+///
+/// - Hourly did estimate ranking
+///      - key: "hourly_rank_dids" || u64 || u64 || nullstr (hour, dids estimate, nsid)
+///      - val: [empty]
+///
+///
 /// - Weekly total record counts and dids estimate per collection
-///      - key: "weekly_counts" || u64 || nullstr (hour, nsid)
+///      - key: "weekly_counts" || u64 || nullstr (week, nsid)
 ///      - val: u64 || HLL (count (not cursor), estimator)
+///
+/// - Weekly record count ranking
+///      - key: "weekly_rank_records" || u64 || u64 || nullstr (week, count, nsid)
+///      - val: [empty]
+///
+/// - Weekly did estimate ranking
+///      - key: "weekly_rank_dids" || u64 || u64 || nullstr (week, dids estimate, nsid)
+///      - val: [empty]
+///
 ///
 /// - All-time total record counts and dids estimate per collection
 ///      - key: "ever_counts" || nullstr (nsid)
 ///      - val: u64 || HLL (count (not cursor), estimator)
 ///
-/// - TODO: sorted indexes for all-times?
+/// - All-time total record record count ranking
+///      - key: "ever_rank_records" || u64 || nullstr (count, nsid)
+///      - val: [empty]
+///
+/// - All-time did estimate ranking
+///      - key: "ever_rank_dids" || u64 || nullstr (dids estimate, nsid)
+///      - val: [empty]
 ///
 ///
 /// Partition: 'queues'

--- a/ufos/src/storage_mem.rs
+++ b/ufos/src/storage_mem.rs
@@ -12,16 +12,16 @@ use crate::store_types::{
     RecordLocationMeta, RecordLocationVal, RecordRawValue, TakeoffKey, TakeoffValue,
     WeekTruncatedCursor, WeeklyRollupKey,
 };
-use crate::{CommitAction, ConsumerInfo, Did, EventBatch, Nsid, TopCollections, UFOsRecord};
+use crate::{
+    CommitAction, ConsumerInfo, Count, Did, EventBatch, Nsid, QueryPeriod, TopCollections,
+    UFOsRecord,
+};
 use async_trait::async_trait;
 use jetstream::events::Cursor;
 use lsm_tree::range::prefix_to_range;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
-use std::sync::Mutex;
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 use std::time::SystemTime;
 
 const MAX_BATCHED_CLEANUP_SIZE: usize = 1024; // try to commit progress for longer feeds
@@ -584,9 +584,16 @@ impl StoreReader for MemReader {
         let s = self.clone();
         tokio::task::spawn_blocking(move || MemReader::get_consumer_info(&s)).await?
     }
-    async fn get_top_collections(&self) -> Result<TopCollections, StorageError> {
+    async fn get_top_collections(&self) -> StorageResult<TopCollections> {
         let s = self.clone();
         tokio::task::spawn_blocking(move || MemReader::get_top_collections(&s)).await?
+    }
+    async fn get_top_collections_by_count(
+        &self,
+        _: usize,
+        _: QueryPeriod,
+    ) -> StorageResult<Vec<Count>> {
+        todo!()
     }
     async fn get_counts_by_collection(&self, collection: &Nsid) -> StorageResult<(u64, u64)> {
         let s = self.clone();

--- a/ufos/src/storage_mem.rs
+++ b/ufos/src/storage_mem.rs
@@ -595,6 +595,13 @@ impl StoreReader for MemReader {
     ) -> StorageResult<Vec<Count>> {
         todo!()
     }
+    async fn get_top_collections_by_dids(
+        &self,
+        _: usize,
+        _: QueryPeriod,
+    ) -> StorageResult<Vec<Count>> {
+        todo!()
+    }
     async fn get_counts_by_collection(&self, collection: &Nsid) -> StorageResult<(u64, u64)> {
         let s = self.clone();
         let collection = collection.clone();

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -291,7 +291,7 @@ pub type BucketedRankRecordsKey<P, C> =
 impl<P, C> BucketedRankRecordsKey<P, C>
 where
     P: StaticStr + PartialEq + std::fmt::Debug,
-    C: DbBytes + PartialEq + std::fmt::Debug,
+    C: DbBytes + PartialEq + std::fmt::Debug + Clone,
 {
     pub fn new(cursor: C, rank: KeyRank, nsid: &Nsid) -> Self {
         Self::from_pair(
@@ -299,8 +299,8 @@ where
             nsid.clone(),
         )
     }
-    pub fn update_rank(&mut self, new_rank: KeyRank) {
-        self.prefix.suffix = new_rank;
+    pub fn with_rank(&self, new_rank: KeyRank) -> Self {
+        Self::new(self.prefix.prefix.suffix.clone(), new_rank, &self.suffix)
     }
 }
 
@@ -363,8 +363,8 @@ where
     pub fn new(rank: KeyRank, nsid: &Nsid) -> Self {
         Self::from_pair(DbConcat::from_pair(Default::default(), rank), nsid.clone())
     }
-    pub fn update_rank(&mut self, new_rank: KeyRank) {
-        self.prefix.suffix = new_rank;
+    pub fn with_rank(&self, new_rank: KeyRank) -> Self {
+        Self::new(new_rank, &self.suffix)
     }
 }
 

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -275,6 +275,16 @@ impl DbBytes for KeyRank {
         Ok((rank, 8))
     }
 }
+impl From<u64> for KeyRank {
+    fn from(n: u64) -> Self {
+        Self(n)
+    }
+}
+impl From<KeyRank> for u64 {
+    fn from(kr: KeyRank) -> Self {
+        kr.0
+    }
+}
 
 pub type BucketedRankRecordsKey<P, C> =
     DbConcat<DbConcat<DbConcat<DbStaticStr<P>, C>, KeyRank>, Nsid>;

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -18,35 +18,17 @@ macro_rules! static_str {
     };
 }
 
-/// key format: ["js_cursor"]
-#[derive(Debug, PartialEq)]
-pub struct JetstreamCursorKey {}
-impl StaticStr for JetstreamCursorKey {
-    fn static_str() -> &'static str {
-        "js_cursor"
-    }
-}
+// key format: ["js_cursor"]
+static_str!("js_cursor", JetstreamCursorKey);
 pub type JetstreamCursorValue = Cursor;
 
-/// key format: ["rollup_cursor"]
-#[derive(Debug, PartialEq)]
-pub struct NewRollupCursorKey {}
-impl StaticStr for NewRollupCursorKey {
-    fn static_str() -> &'static str {
-        "rollup_cursor"
-    }
-}
+// key format: ["rollup_cursor"]
+static_str!("rollup_cursor", NewRollupCursorKey);
 // pub type NewRollupCursorKey = DbStaticStr<_NewRollupCursorKey>;
 /// value format: [rollup_cursor(Cursor)|collection(Nsid)]
 pub type NewRollupCursorValue = Cursor;
 
-#[derive(Debug, PartialEq)]
-pub struct _TrimCollectionStaticStr {}
-impl StaticStr for _TrimCollectionStaticStr {
-    fn static_str() -> &'static str {
-        "trim_cursor"
-    }
-}
+static_str!("trim_cursor", _TrimCollectionStaticStr);
 type TrimCollectionCursorPrefix = DbStaticStr<_TrimCollectionStaticStr>;
 pub type TrimCollectionCursorKey = DbConcat<TrimCollectionCursorPrefix, Nsid>;
 impl TrimCollectionCursorKey {
@@ -56,24 +38,12 @@ impl TrimCollectionCursorKey {
 }
 pub type TrimCollectionCursorVal = Cursor;
 
-/// key format: ["js_endpoint"]
-#[derive(Debug, PartialEq)]
-pub struct TakeoffKey {}
-impl StaticStr for TakeoffKey {
-    fn static_str() -> &'static str {
-        "takeoff"
-    }
-}
+// key format: ["js_endpoint"]
+static_str!("takeoff", TakeoffKey);
 pub type TakeoffValue = Cursor;
 
-/// key format: ["js_endpoint"]
-#[derive(Debug, PartialEq)]
-pub struct JetstreamEndpointKey {}
-impl StaticStr for JetstreamEndpointKey {
-    fn static_str() -> &'static str {
-        "js_endpoint"
-    }
-}
+// key format: ["js_endpoint"]
+static_str!("js_endpoint", JetstreamEndpointKey);
 #[derive(Debug, PartialEq)]
 pub struct JetstreamEndpointValue(pub String);
 /// String wrapper for jetstream endpoint value
@@ -199,13 +169,7 @@ impl From<(Cursor, &str, PutAction)> for RecordLocationVal {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct _LiveRecordsStaticStr {}
-impl StaticStr for _LiveRecordsStaticStr {
-    fn static_str() -> &'static str {
-        "live_counts"
-    }
-}
+static_str!("live_counts", _LiveRecordsStaticStr);
 
 type LiveCountsStaticPrefix = DbStaticStr<_LiveRecordsStaticStr>;
 type LiveCountsCursorPrefix = DbConcat<LiveCountsStaticPrefix, Cursor>;
@@ -285,13 +249,7 @@ impl Default for CountsValue {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct _DeleteAccountStaticStr {}
-impl StaticStr for _DeleteAccountStaticStr {
-    fn static_str() -> &'static str {
-        "delete_acount"
-    }
-}
+static_str!("delete_acount", _DeleteAccountStaticStr);
 pub type DeleteAccountStaticPrefix = DbStaticStr<_DeleteAccountStaticStr>;
 pub type DeleteAccountQueueKey = DbConcat<DeleteAccountStaticPrefix, Cursor>;
 impl DeleteAccountQueueKey {
@@ -336,13 +294,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct _HourlyRollupStaticStr {}
-impl StaticStr for _HourlyRollupStaticStr {
-    fn static_str() -> &'static str {
-        "hourly_counts"
-    }
-}
+static_str!("hourly_counts", _HourlyRollupStaticStr);
 pub type HourlyRollupStaticPrefix = DbStaticStr<_HourlyRollupStaticStr>;
 pub type HourlyRollupKey = DbConcat<DbConcat<HourlyRollupStaticPrefix, HourTruncatedCursor>, Nsid>;
 impl HourlyRollupKey {
@@ -361,13 +313,7 @@ pub type HourlyRecordsKey = BucketedRankRecordsKey<_HourlyRecordsStaticStr, Hour
 static_str!("hourly_rank_dids", _HourlyDidsStaticStr);
 pub type HourlyDidsKey = BucketedRankRecordsKey<_HourlyDidsStaticStr, HourTruncatedCursor>;
 
-#[derive(Debug, PartialEq)]
-pub struct _WeeklyRollupStaticStr {}
-impl StaticStr for _WeeklyRollupStaticStr {
-    fn static_str() -> &'static str {
-        "weekly_counts"
-    }
-}
+static_str!("weekly_counts", _WeeklyRollupStaticStr);
 pub type WeeklyRollupStaticPrefix = DbStaticStr<_WeeklyRollupStaticStr>;
 pub type WeeklyRollupKey = DbConcat<DbConcat<WeeklyRollupStaticPrefix, WeekTruncatedCursor>, Nsid>;
 impl WeeklyRollupKey {
@@ -386,13 +332,7 @@ pub type WeeklyRecordsKey = BucketedRankRecordsKey<_WeeklyRecordsStaticStr, Week
 static_str!("weekly_rank_dids", _WeeklyDidsStaticStr);
 pub type WeeklyDidsKey = BucketedRankRecordsKey<_WeeklyDidsStaticStr, WeekTruncatedCursor>;
 
-#[derive(Debug, PartialEq)]
-pub struct _AllTimeRollupStaticStr {}
-impl StaticStr for _AllTimeRollupStaticStr {
-    fn static_str() -> &'static str {
-        "ever_counts"
-    }
-}
+static_str!("ever_counts", _AllTimeRollupStaticStr);
 pub type AllTimeRollupStaticPrefix = DbStaticStr<_AllTimeRollupStaticStr>;
 pub type AllTimeRollupKey = DbConcat<AllTimeRollupStaticPrefix, Nsid>;
 impl AllTimeRollupKey {

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -366,7 +366,7 @@ where
     pub fn with_rank(&self, new_rank: KeyRank) -> Self {
         Self::new(new_rank, &self.suffix.suffix)
     }
-    pub fn records(&self) -> u64 {
+    pub fn count(&self) -> u64 {
         self.suffix.prefix.0
     }
     pub fn collection(&self) -> &Nsid {


### PR DESCRIPTION
adds six new index rollups: hourly, weekly, and all-time rankings for NSIDs by both total records and estimated DIDs.

going to mostly copy-pasta the read impls for now to get things working, but i'm certain they can be refactored to be much cleaner later.