### PR TITLE
UFOs HLL DID-hashing: secret prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1909,7 +1909,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -2697,13 +2697,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2741,7 +2740,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -3426,7 +3425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.5",
  "windows-sys 0.59.0",
@@ -3794,7 +3793,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.0",
+ "rand 0.9.1",
  "sha1",
  "thiserror 2.0.12",
  "url",
@@ -3819,6 +3818,7 @@ dependencies = [
  "dropshot",
  "env_logger",
  "fjall",
+ "getrandom 0.3.3",
  "http",
  "jetstream",
  "log",
@@ -3917,7 +3917,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,13 +574,13 @@ dependencies = [
 
 [[package]]
 name = "cardinality-estimator-safe"
-version = "2.1.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c14632b90cb42ff2174d2a544ca553c1bccfab54b848ae9ab9e004b90243bf"
+checksum = "b41ec0cd313b46ba3b508377544b25aa1d56d05ce9e657e77dfb001d5e726e53"
 dependencies = [
+ "digest",
  "enum_dispatch",
  "serde",
- "wyhash",
 ]
 
 [[package]]
@@ -3226,6 +3226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3827,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.12",
  "tikv-jemallocator",

--- a/ufos/Cargo.toml
+++ b/ufos/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5.31", features = ["derive"] }
 dropshot = "0.16.0"
 env_logger = "0.11.7"
 fjall = { version = "2.8.0", features = ["lz4"] }
+getrandom = "0.3.3"
 http = "1.3.1"
 jetstream = { path = "../jetstream" }
 log = "0.4.26"

--- a/ufos/Cargo.toml
+++ b/ufos/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.97"
 async-trait = "0.1.88"
 bincode = { version = "2.0.1", features = ["serde"] }
-cardinality-estimator-safe = { version = "2.1.1", features = ["with_serde"] }
+cardinality-estimator-safe = { version = "4.0.1", features = ["with_serde", "with_digest"] }
 clap = { version = "4.5.31", features = ["derive"] }
 dropshot = "0.16.0"
 env_logger = "0.11.7"
@@ -20,6 +20,7 @@ schemars = { version = "0.8.22", features = ["raw_value"] }
 semver = "1.0.26"
 serde = "1.0.219"
 serde_json = "1.0.140"
+sha2 = "0.10.9"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full", "sync", "time"] }
 

--- a/ufos/src/db_types.rs
+++ b/ufos/src/db_types.rs
@@ -224,6 +224,8 @@ pub trait SerdeBytes: serde::Serialize + for<'a> serde::Deserialize<'a> {
 
 //////
 
+impl<const N: usize> UseBincodePlz for [u8; N] {}
+
 impl DbBytes for Vec<u8> {
     fn to_db_bytes(&self) -> Result<Vec<u8>, EncodingError> {
         Ok(self.to_vec())

--- a/ufos/src/file_consumer.rs
+++ b/ufos/src/file_consumer.rs
@@ -1,4 +1,5 @@
 use crate::consumer::{Batcher, LimitedBatch, BATCH_QUEUE_SIZE};
+use crate::store_types::SketchSecretPrefix;
 use anyhow::Result;
 use jetstream::{error::JetstreamEventError, events::JetstreamEvent};
 use std::path::PathBuf;
@@ -21,11 +22,14 @@ async fn read_jsonl(f: File, sender: Sender<JetstreamEvent>) -> Result<()> {
     Ok(())
 }
 
-pub async fn consume(p: PathBuf) -> Result<Receiver<LimitedBatch>> {
+pub async fn consume(
+    p: PathBuf,
+    sketch_secret: SketchSecretPrefix,
+) -> Result<Receiver<LimitedBatch>> {
     let f = File::open(p).await?;
     let (jsonl_sender, jsonl_receiver) = channel::<JetstreamEvent>(16);
     let (batch_sender, batch_reciever) = channel::<LimitedBatch>(BATCH_QUEUE_SIZE);
-    let mut batcher = Batcher::new(jsonl_receiver, batch_sender);
+    let mut batcher = Batcher::new(jsonl_receiver, batch_sender, sketch_secret);
     tokio::task::spawn(async move { read_jsonl(f, jsonl_sender).await });
     tokio::task::spawn(async move { batcher.run().await });
     Ok(batch_reciever)

--- a/ufos/src/storage.rs
+++ b/ufos/src/storage.rs
@@ -1,3 +1,4 @@
+use crate::store_types::SketchSecretPrefix;
 use crate::{
     error::StorageError, ConsumerInfo, Count, Cursor, EventBatch, QueryPeriod, TopCollections,
     UFOsRecord,
@@ -16,7 +17,7 @@ pub trait StorageWhatever<R: StoreReader, W: StoreWriter<B>, B: StoreBackground,
         endpoint: String,
         force_endpoint: bool,
         config: C,
-    ) -> StorageResult<(R, W, Option<Cursor>)>
+    ) -> StorageResult<(R, W, Option<Cursor>, SketchSecretPrefix)>
     where
         Self: Sized;
 }

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -3,7 +3,7 @@ use crate::db_types::{
 };
 use crate::{Cursor, Did, Nsid, PutAction, RecordKey, UFOsCommit};
 use bincode::{Decode, Encode};
-use cardinality_estimator_safe::CardinalityEstimator;
+use cardinality_estimator_safe::Sketch;
 use std::ops::Range;
 
 macro_rules! static_str {
@@ -199,7 +199,7 @@ pub struct TotalRecordsValue(pub u64);
 impl UseBincodePlz for TotalRecordsValue {}
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct EstimatedDidsValue(pub CardinalityEstimator<Did>);
+pub struct EstimatedDidsValue(pub Sketch<14>);
 impl SerdeBytes for EstimatedDidsValue {}
 impl DbBytes for EstimatedDidsValue {
     #[cfg(test)]
@@ -223,7 +223,7 @@ impl DbBytes for EstimatedDidsValue {
 
 pub type CountsValue = DbConcat<TotalRecordsValue, EstimatedDidsValue>;
 impl CountsValue {
-    pub fn new(total: u64, dids: CardinalityEstimator<Did>) -> Self {
+    pub fn new(total: u64, dids: Sketch<14>) -> Self {
         Self {
             prefix: TotalRecordsValue(total),
             suffix: EstimatedDidsValue(dids),
@@ -232,7 +232,7 @@ impl CountsValue {
     pub fn records(&self) -> u64 {
         self.prefix.0
     }
-    pub fn dids(&self) -> &CardinalityEstimator<Did> {
+    pub fn dids(&self) -> &Sketch<14> {
         &self.suffix.0
     }
     pub fn merge(&mut self, other: &Self) {
@@ -244,7 +244,7 @@ impl Default for CountsValue {
     fn default() -> Self {
         Self {
             prefix: TotalRecordsValue(0),
-            suffix: EstimatedDidsValue(CardinalityEstimator::new()),
+            suffix: EstimatedDidsValue(Sketch::<14>::default()),
         }
     }
 }
@@ -433,10 +433,12 @@ pub type WeekTruncatedCursor = TruncatedCursor<WEEK_IN_MICROS>;
 #[cfg(test)]
 mod test {
     use super::{
-        CardinalityEstimator, CountsValue, Cursor, Did, EncodingError, HourTruncatedCursor,
-        HourlyRollupKey, Nsid, HOUR_IN_MICROS,
+        CountsValue, Cursor, Did, EncodingError, HourTruncatedCursor, HourlyRollupKey, Nsid,
+        Sketch, HOUR_IN_MICROS,
     };
     use crate::db_types::DbBytes;
+    use cardinality_estimator_safe::Element;
+    use sha2::Sha256;
 
     #[test]
     fn test_by_hourly_rollup_key() -> Result<(), EncodingError> {
@@ -456,9 +458,14 @@ mod test {
 
     #[test]
     fn test_by_hourly_rollup_value() -> Result<(), EncodingError> {
-        let mut estimator = CardinalityEstimator::new();
+        let mut estimator = Sketch::<14>::default();
+        fn to_element(d: Did) -> Element<14> {
+            Element::from_digest_oneshot::<Sha256>(d.to_string().as_bytes())
+        }
         for i in 0..10 {
-            estimator.insert(&Did::new(format!("did:plc:inze6wrmsm7pjl7yta3oig7{i}")).unwrap());
+            estimator.insert(to_element(
+                Did::new(format!("did:plc:inze6wrmsm7pjl7yta3oig7{i}")).unwrap(),
+            ));
         }
         let original = CountsValue::new(123, estimator.clone());
         let serialized = original.to_db_bytes()?;
@@ -467,7 +474,9 @@ mod test {
         assert_eq!(bytes_consumed, serialized.len());
 
         for i in 10..1_000 {
-            estimator.insert(&Did::new(format!("did:plc:inze6wrmsm7pjl7yta3oig{i}")).unwrap());
+            estimator.insert(to_element(
+                Did::new(format!("did:plc:inze6wrmsm7pjl7yta3oig{i}")).unwrap(),
+            ));
         }
         let original = CountsValue::new(123, estimator);
         let serialized = original.to_db_bytes()?;

--- a/ufos/src/store_types.rs
+++ b/ufos/src/store_types.rs
@@ -22,6 +22,10 @@ macro_rules! static_str {
 static_str!("js_cursor", JetstreamCursorKey);
 pub type JetstreamCursorValue = Cursor;
 
+// key format: ["sketch_secret"]
+static_str!("sketch_secret", SketchSecretKey);
+pub type SketchSecretPrefix = [u8; 16];
+
 // key format: ["rollup_cursor"]
 static_str!("rollup_cursor", NewRollupCursorKey);
 // pub type NewRollupCursorKey = DbStaticStr<_NewRollupCursorKey>;


### PR DESCRIPTION
make it harder to do an offline attack search for high-impact DIDs that could be used to inflate unique user counts for specific NSIDs.

the secret is stored in the db because that way it's hard to lose and gets backed up with the data. strict secrecy is not worth enough to risk poisoning a whole db of sketches if i somehow lose it.

it's not the end of the world if it leaks, and eventually it probably will since it can never be rotated. it will just mean some worse estimates if someone makes a lot of effort to do that.

(and it really is probably a lot of effort: there's P=2^14 buckets in the sketches, and everything is time-based so while they can permanently mess with all-time stats, it would take constant effort to keep counts-over-time inflated.)