### PR TITLE
fixes at-microcosm/links#24 for constellation /links/distinct-dids to…

### DIFF
--- a/constellation/src/server/mod.rs
+++ b/constellation/src/server/mod.rs
@@ -274,6 +274,10 @@ fn get_links(
         .get_links(&query.target, &query.collection, &query.path, limit, until)
         .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let total = store
+        .get_count(&query.target, &query.collection, &query.path)
+        .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
+
     let cursor = paged.next.map(|next| {
         ApiCursor {
             version: paged.version,
@@ -285,7 +289,7 @@ fn get_links(
     Ok(acceptable(
         accept,
         GetLinkItemsResponse {
-            total: paged.version.0,
+            total: total,
             linking_records: paged.items,
             cursor,
             query: (*query).clone(),
@@ -335,6 +339,12 @@ fn get_distinct_dids(
         .get_distinct_dids(&query.target, &query.collection, &query.path, limit, until)
         .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let distinct_dids_total = store
+        .get_distinct_did_count(&query.target, &query.collection, &query.path)
+        .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
+
+
+
     let cursor = paged.next.map(|next| {
         ApiCursor {
             version: paged.version,
@@ -346,7 +356,7 @@ fn get_distinct_dids(
     Ok(acceptable(
         accept,
         GetDidItemsResponse {
-            total: paged.version.0,
+            total: distinct_dids_total,
             linking_dids: paged.items,
             cursor,
             query: (*query).clone(),

--- a/constellation/src/server/mod.rs
+++ b/constellation/src/server/mod.rs
@@ -274,10 +274,6 @@ fn get_links(
         .get_links(&query.target, &query.collection, &query.path, limit, until)
         .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let total = store
-        .get_count(&query.target, &query.collection, &query.path)
-        .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
-
     let cursor = paged.next.map(|next| {
         ApiCursor {
             version: paged.version,
@@ -289,7 +285,7 @@ fn get_links(
     Ok(acceptable(
         accept,
         GetLinkItemsResponse {
-            total: total,
+            total: paged.total,
             linking_records: paged.items,
             cursor,
             query: (*query).clone(),
@@ -339,12 +335,6 @@ fn get_distinct_dids(
         .get_distinct_dids(&query.target, &query.collection, &query.path, limit, until)
         .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let distinct_dids_total = store
-        .get_distinct_did_count(&query.target, &query.collection, &query.path)
-        .map_err(|_| http::StatusCode::INTERNAL_SERVER_ERROR)?;
-
-
-
     let cursor = paged.next.map(|next| {
         ApiCursor {
             version: paged.version,
@@ -356,7 +346,7 @@ fn get_distinct_dids(
     Ok(acceptable(
         accept,
         GetDidItemsResponse {
-            total: distinct_dids_total,
+            total: paged.total,
             linking_dids: paged.items,
             cursor,
             query: (*query).clone(),

--- a/constellation/src/storage/mem_store.rs
+++ b/constellation/src/storage/mem_store.rs
@@ -173,6 +173,7 @@ impl LinkReader for MemStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
         let Some(did_rkeys) = paths.get(&Source::new(collection, path)) else {
@@ -180,6 +181,7 @@ impl LinkReader for MemStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
 
@@ -209,6 +211,7 @@ impl LinkReader for MemStorage {
             version: (total as u64, gone as u64),
             items,
             next,
+            total: alive as u64,
         })
     }
 
@@ -226,6 +229,7 @@ impl LinkReader for MemStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
         let Some(did_rkeys) = paths.get(&Source::new(collection, path)) else {
@@ -233,6 +237,7 @@ impl LinkReader for MemStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
 
@@ -275,6 +280,7 @@ impl LinkReader for MemStorage {
             version: (total as u64, gone as u64),
             items,
             next,
+            total: alive as u64,
         })
     }
 

--- a/constellation/src/storage/mod.rs
+++ b/constellation/src/storage/mod.rs
@@ -150,6 +150,7 @@ mod tests {
                 version: (0, 0),
                 items: vec![],
                 next: None,
+                total: 0,
             }
         );
         assert_eq!(
@@ -158,6 +159,7 @@ mod tests {
                 version: (0, 0),
                 items: vec![],
                 next: None,
+                total: 0,
             }
         );
         assert_eq!(storage.get_all_counts("bad-example.com")?, HashMap::new());
@@ -648,6 +650,7 @@ mod tests {
                     rkey: "asdf".into(),
                 }],
                 next: None,
+                total: 1,
             }
         );
         assert_eq!(
@@ -656,6 +659,7 @@ mod tests {
                 version: (1, 0),
                 items: vec!["did:plc:asdf".into()],
                 next: None,
+                total: 1,
             }
         );
         assert_stats(storage.get_stats()?, 1..=1, 1..=1, 1..=1);
@@ -697,6 +701,7 @@ mod tests {
                     },
                 ],
                 next: Some(3),
+                total: 5,
             }
         );
         assert_eq!(
@@ -705,6 +710,7 @@ mod tests {
                 version: (5, 0),
                 items: vec!["did:plc:asdf-5".into(), "did:plc:asdf-4".into()],
                 next: Some(3),
+                total: 5,
             }
         );
         let links = storage.get_links("a.com", "app.t.c", ".abc.uri", 2, links.next)?;
@@ -726,6 +732,7 @@ mod tests {
                     },
                 ],
                 next: Some(1),
+                total: 5,
             }
         );
         assert_eq!(
@@ -734,6 +741,7 @@ mod tests {
                 version: (5, 0),
                 items: vec!["did:plc:asdf-3".into(), "did:plc:asdf-2".into()],
                 next: Some(1),
+                total: 5,
             }
         );
         let links = storage.get_links("a.com", "app.t.c", ".abc.uri", 2, links.next)?;
@@ -748,6 +756,7 @@ mod tests {
                     rkey: "asdf".into(),
                 },],
                 next: None,
+                total: 5,
             }
         );
         assert_eq!(
@@ -756,6 +765,7 @@ mod tests {
                 version: (5, 0),
                 items: vec!["did:plc:asdf-1".into()],
                 next: None,
+                total: 5,
             }
         );
         assert_stats(storage.get_stats()?, 5..=5, 1..=1, 5..=5);
@@ -796,6 +806,7 @@ mod tests {
                     },
                 ],
                 next: Some(2),
+                total: 4,
             }
         );
         let links = storage.get_links("a.com", "app.t.c", ".abc.uri", 2, links.next)?;
@@ -816,6 +827,7 @@ mod tests {
                     },
                 ],
                 next: None,
+                total: 4,
             }
         );
         assert_stats(storage.get_stats()?, 4..=4, 1..=1, 4..=4);
@@ -856,6 +868,7 @@ mod tests {
                     },
                 ],
                 next: Some(2),
+                total: 4,
             }
         );
         storage.push(
@@ -890,6 +903,7 @@ mod tests {
                     },
                 ],
                 next: None,
+                total: 5,
             }
         );
         assert_stats(storage.get_stats()?, 5..=5, 1..=1, 5..=5);
@@ -930,6 +944,7 @@ mod tests {
                     },
                 ],
                 next: Some(2),
+                total: 4,
             }
         );
         storage.push(
@@ -951,6 +966,7 @@ mod tests {
                     rkey: "asdf".into(),
                 },],
                 next: None,
+                total: 3,
             }
         );
         assert_stats(storage.get_stats()?, 4..=4, 1..=1, 3..=3);
@@ -991,6 +1007,7 @@ mod tests {
                     },
                 ],
                 next: Some(2),
+                total: 4,
             }
         );
         storage.push(
@@ -1008,6 +1025,7 @@ mod tests {
                     rkey: "asdf".into(),
                 },],
                 next: None,
+                total: 4,
             }
         );
         assert_stats(storage.get_stats()?, 4..=4, 1..=1, 4..=4);

--- a/constellation/src/storage/mod.rs
+++ b/constellation/src/storage/mod.rs
@@ -16,6 +16,7 @@ pub struct PagedAppendingCollection<T> {
     pub version: (u64, u64), // (collection length, deleted item count) // TODO: change to (total, active)? since dedups isn't "deleted"
     pub items: Vec<T>,
     pub next: Option<u64>,
+    pub total: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]

--- a/constellation/src/storage/rocks_store.rs
+++ b/constellation/src/storage/rocks_store.rs
@@ -872,6 +872,7 @@ impl LinkReader for RocksStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
 
@@ -914,6 +915,7 @@ impl LinkReader for RocksStorage {
             version: (total, gone),
             items,
             next,
+            total: alive,
         })
     }
 
@@ -936,6 +938,7 @@ impl LinkReader for RocksStorage {
                 version: (0, 0),
                 items: Vec::new(),
                 next: None,
+                total: 0,
             });
         };
 
@@ -974,6 +977,7 @@ impl LinkReader for RocksStorage {
             version: (total, gone),
             items,
             next,
+            total: alive,
         })
     }
 


### PR DESCRIPTION
Uses LinkReader::get_count and LinkReader::get_distinct_did_count from constellation/storage/mod.rs to fetch correct unique dids. Please double check that this works.